### PR TITLE
Enable building on Windows

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2017-03-25  Joshua Ulrich  <josh.m.ulrich@gmail.com>
+
+	* src/datetime.c: Bugfix; now works on Windows
+	* DESCRIPTION (OS_type): Remove restriction
+
 2017-03-23  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): Release 0.0.1

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,6 +10,5 @@ Description: Access to the C-level R date and datetime code is provided for
  Client packages simply include a single header 'RApiDatetime.h' provided
  by this package, and also 'import' it.  The R Core group is the original
  author of the code made available with slight modifications by this package. 
-OS_type: unix
 License: GPL (>= 2)
 RoxygenNote: 6.0.1

--- a/src/datetime.c
+++ b/src/datetime.c
@@ -96,7 +96,7 @@ char *R_tzname[2];
 
 typedef struct tm stm;
 #define R_tzname tzname
-# if defined(__CYGWIN__)
+# if defined(__CYGWIN__) || defined(_WIN32)
 extern __declspec(dllimport) char *tzname[2];
 # else
 extern char *tzname[2];


### PR DESCRIPTION
An attempt to install the package on Windows (after removing the OS
restriction) resulted in the following warning:

```
datetime.c:102:14: warning: 'tzname' redeclared without dllimport attribute: previous dllimport ignored [-Wattributes]
 extern char *tzname[2];
               ^
```

The fix is to declare tzname with the dllimport attribute, as was done
for Cygwin.

While researching how R itself configures this block of code, I learned
that USE_INTERNAL_MKTIME is set by default. It is unset if configure
determines that the system tools behave reasonably. It's set by default
on MacOS, and it's what is used on Windows.